### PR TITLE
Add multilingual support to userPanel

### DIFF
--- a/userPanel/index.ts
+++ b/userPanel/index.ts
@@ -20,7 +20,7 @@ export class UserPanelModule extends Module {
             id: 'back',
             // back arriw icon
             icon: `<svg class="w-6 h-6 text-discord-white/60 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>`,
-            label: 'Cambiar de servidor',
+            label: '$userPanel.nav.back',
             url: '/panel',
             order: 1,
             category: 'general',
@@ -28,7 +28,7 @@ export class UserPanelModule extends Module {
         navigationService.registerItem({
             id: 'dashboard',
             icon: `<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="currentColor"  class="icon icon-tabler icons-tabler-filled icon-tabler-layout-dashboard"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 3a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-6a2 2 0 0 1 2 -2zm0 12a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-2a2 2 0 0 1 2 -2zm10 -4a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-6a2 2 0 0 1 2 -2zm0 -8a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-2a2 2 0 0 1 2 -2z" /></svg>`,
-            label: 'Dashboard',
+            label: '$userPanel.nav.dashboard',
             url: '/panel/:guildId(\\d+)',
             order: 2,
             category: 'general',
@@ -36,10 +36,10 @@ export class UserPanelModule extends Module {
                 showDropdown: false,
                 sections: [
                     {
-                        label: 'General',
+                        label: '$userPanel.sidebar.general',
                         items: [
                             {
-                                label: 'Dashboard',
+                                label: '$userPanel.nav.dashboard',
                                 url: '/panel/:guildId(\\d+)',
                             },
                         ],

--- a/userPanel/index.ts
+++ b/userPanel/index.ts
@@ -2,6 +2,7 @@ import { Module, ServiceContainer, ZumitoFramework } from "zumito-framework";
 import { UserPanelNavigationService } from "./services/UserPanelNavigationService";
 import { UserPanelViewService } from "./services/UserPanelViewService";
 import { UserPanelAuthService } from "./services/UserPanelAuthService";
+import { UserPanelLanguageManager } from "./services/UserPanelLanguageManager";
 
 export class UserPanelModule extends Module {
     constructor(modulePath: string, framework: ZumitoFramework) {
@@ -10,6 +11,7 @@ export class UserPanelModule extends Module {
         ServiceContainer.addService(UserPanelNavigationService, [], true);
         ServiceContainer.addService(UserPanelViewService, [], true);
         ServiceContainer.addService(UserPanelAuthService, [], true);
+        ServiceContainer.addService(UserPanelLanguageManager, [], true);
 
         this.registerDashboardItem();
     }
@@ -20,7 +22,7 @@ export class UserPanelModule extends Module {
             id: 'back',
             // back arriw icon
             icon: `<svg class="w-6 h-6 text-discord-white/60 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>`,
-            label: '$userPanel.nav.back',
+            label: 'userPanel.nav.back',
             url: '/panel',
             order: 1,
             category: 'general',
@@ -28,7 +30,7 @@ export class UserPanelModule extends Module {
         navigationService.registerItem({
             id: 'dashboard',
             icon: `<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="currentColor"  class="icon icon-tabler icons-tabler-filled icon-tabler-layout-dashboard"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 3a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-6a2 2 0 0 1 2 -2zm0 12a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-2a2 2 0 0 1 2 -2zm10 -4a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-6a2 2 0 0 1 2 -2zm0 -8a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-2a2 2 0 0 1 2 -2z" /></svg>`,
-            label: '$userPanel.nav.dashboard',
+            label: 'userPanel.nav.dashboard',
             url: '/panel/:guildId(\\d+)',
             order: 2,
             category: 'general',
@@ -36,10 +38,10 @@ export class UserPanelModule extends Module {
                 showDropdown: false,
                 sections: [
                     {
-                        label: '$userPanel.sidebar.general',
+                        label: 'userPanel.sidebar.general',
                         items: [
                             {
-                                label: '$userPanel.nav.dashboard',
+                                label: 'userPanel.nav.dashboard',
                                 url: '/panel/:guildId(\\d+)',
                             },
                         ],

--- a/userPanel/routes/UserPanel.ts
+++ b/userPanel/routes/UserPanel.ts
@@ -6,6 +6,7 @@ import { Client } from "zumito-framework/discord";
 import { PermissionFlagsBits } from "discord.js";
 import { UserPanelViewService } from "../services/UserPanelViewService";
 import { UserPanelAuthService } from "../services/UserPanelAuthService";
+import { UserPanelLanguageManager } from "../services/UserPanelLanguageManager";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -16,6 +17,7 @@ export class UserPanel extends Route {
     constructor(
         private client: Client = ServiceContainer.getService(Client),
         private userPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
+        private userPanelLanguageManager = ServiceContainer.getService(UserPanelLanguageManager),
     ) {
         super();
     }
@@ -57,6 +59,7 @@ export class UserPanel extends Route {
                 });
             }
         }
+        const { lang, t, availableLanguages, defaultLanguage } = this.userPanelLanguageManager.getLanguageVariables(req, res);
         const content = await ejs.renderFile(
             path.resolve(__dirname, '../views/dashboard.ejs'),
             {
@@ -64,6 +67,7 @@ export class UserPanel extends Route {
                 botName,
                 botId,
                 botAvatar,
+                lang, t, availableLanguages, defaultLanguage
             }
         );
         const userPanelView = new UserPanelViewService();

--- a/userPanel/services/UserPanelLanguageManager.ts
+++ b/userPanel/services/UserPanelLanguageManager.ts
@@ -1,0 +1,39 @@
+import { type Request, type Response } from "express";
+import { ServiceContainer, TranslationManager } from "zumito-framework";
+
+export class UserPanelLanguageManager {
+
+    constructor(
+        private translationManager = ServiceContainer.getService(TranslationManager),
+        
+    ) {}
+
+    public getLanguageVariables(req: Request, res: Response) {
+        const availableLanguages = this.translationManager.getLanguages();
+        const defaultLanguage = this.translationManager.getDefaultLanguage();
+        let lang = req.cookies?.panel_lang;
+        if (!lang || !availableLanguages.includes(lang)) {
+            const header = req.headers['accept-language'] as string | undefined;
+            if (header) {
+                const parts = header.split(',').map(p => p.split(';')[0].trim());
+                lang = parts.map(p => p.slice(0, 2)).find(l => availableLanguages.includes(l));
+            }
+            if (!lang) lang = defaultLanguage;
+            res.cookie('panel_lang', lang, {
+                httpOnly: false,
+                secure: false,
+                sameSite: 'lax',
+                maxAge: 30 * 24 * 60 * 60 * 1000,
+                path: '/',
+            });
+        }
+        const t = (key: string, params?: Record<string, any>) => this.translationManager.get(key, lang, params);
+        return {
+            lang,
+            t,
+            availableLanguages,
+            defaultLanguage,
+        }
+    }
+
+}

--- a/userPanel/services/UserPanelViewService.ts
+++ b/userPanel/services/UserPanelViewService.ts
@@ -1,4 +1,4 @@
-import { ServiceContainer } from "zumito-framework";
+import { ServiceContainer, TranslationManager } from "zumito-framework";
 import { Client } from "zumito-framework/discord";
 import { UserPanelNavigationService } from "./UserPanelNavigationService";
 import ejs from "ejs";
@@ -15,6 +15,7 @@ export class UserPanelViewService {
         private client = ServiceContainer.getService(Client),
         private navigationService = ServiceContainer.getService(UserPanelNavigationService),
         private userPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
+        private translationManager = ServiceContainer.getService(TranslationManager),
     ) {}
 
     async render({
@@ -52,6 +53,26 @@ export class UserPanelViewService {
         }
         const botName = this.client.user?.username || "Zumito";
         const tokenData = await this.userPanelAuthService.isLoginValid(req).then(result => result.data);
+
+        const availableLanguages = this.translationManager.getLanguages();
+        const defaultLanguage = this.translationManager.getDefaultLanguage();
+        let lang = req.cookies?.panel_lang;
+        if (!lang || !availableLanguages.includes(lang)) {
+            const header = req.headers['accept-language'] as string | undefined;
+            if (header) {
+                const parts = header.split(',').map(p => p.split(';')[0].trim());
+                lang = parts.map(p => p.slice(0, 2)).find(l => availableLanguages.includes(l));
+            }
+            if (!lang) lang = defaultLanguage;
+            res.cookie('panel_lang', lang, {
+                httpOnly: false,
+                secure: false,
+                sameSite: 'lax',
+                maxAge: 30 * 24 * 60 * 60 * 1000,
+                path: '/',
+            });
+        }
+        const t = this.translationManager.getShortHandMethod('', lang);
         return await ejs.renderFile(
             UserPanelViewService.layoutPath,
             {
@@ -61,6 +82,9 @@ export class UserPanelViewService {
                 selectedNavItem,
                 botName,
                 reqPath,
+                languages: availableLanguages,
+                lang,
+                t,
                 ...options.extra,
                 hideSidebar: options.hideSidebar || false,
             }

--- a/userPanel/services/UserPanelViewService.ts
+++ b/userPanel/services/UserPanelViewService.ts
@@ -5,6 +5,7 @@ import ejs from "ejs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { UserPanelAuthService } from "./UserPanelAuthService";
+import { UserPanelLanguageManager } from "./UserPanelLanguageManager";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -16,6 +17,7 @@ export class UserPanelViewService {
         private navigationService = ServiceContainer.getService(UserPanelNavigationService),
         private userPanelAuthService = ServiceContainer.getService(UserPanelAuthService),
         private translationManager = ServiceContainer.getService(TranslationManager),
+        private userPanelLanguageManager = ServiceContainer.getService(UserPanelLanguageManager),
     ) {}
 
     async render({
@@ -54,25 +56,8 @@ export class UserPanelViewService {
         const botName = this.client.user?.username || "Zumito";
         const tokenData = await this.userPanelAuthService.isLoginValid(req).then(result => result.data);
 
-        const availableLanguages = this.translationManager.getLanguages();
-        const defaultLanguage = this.translationManager.getDefaultLanguage();
-        let lang = req.cookies?.panel_lang;
-        if (!lang || !availableLanguages.includes(lang)) {
-            const header = req.headers['accept-language'] as string | undefined;
-            if (header) {
-                const parts = header.split(',').map(p => p.split(';')[0].trim());
-                lang = parts.map(p => p.slice(0, 2)).find(l => availableLanguages.includes(l));
-            }
-            if (!lang) lang = defaultLanguage;
-            res.cookie('panel_lang', lang, {
-                httpOnly: false,
-                secure: false,
-                sameSite: 'lax',
-                maxAge: 30 * 24 * 60 * 60 * 1000,
-                path: '/',
-            });
-        }
-        const t = this.translationManager.getShortHandMethod('', lang);
+        const { lang, t, availableLanguages, defaultLanguage } = this.userPanelLanguageManager.getLanguageVariables(req, res);
+
         return await ejs.renderFile(
             UserPanelViewService.layoutPath,
             {

--- a/userPanel/translations/en.json
+++ b/userPanel/translations/en.json
@@ -1,0 +1,15 @@
+{
+  "userPanel": {
+    "nav": {
+      "back": "Change server",
+      "dashboard": "Dashboard"
+    },
+    "sidebar": {
+      "general": "General"
+    },
+    "no_servers": "You are not administrator in any server where the bot is present.",
+    "modules": "Modules",
+    "noSection": "No section available",
+    "servers_admin": "Servers where you are administrator"
+  }
+}

--- a/userPanel/translations/es.json
+++ b/userPanel/translations/es.json
@@ -1,0 +1,15 @@
+{
+  "userPanel": {
+    "nav": {
+      "back": "Cambiar de servidor",
+      "dashboard": "Dashboard"
+    },
+    "sidebar": {
+      "general": "General"
+    },
+    "no_servers": "No eres administrador en ningún servidor donde esté el bot.",
+    "modules": "Módulos",
+    "noSection": "Ninguna sección disponible",
+    "servers_admin": "Servidores donde eres administrador"
+  }
+}

--- a/userPanel/views/dashboard.ejs
+++ b/userPanel/views/dashboard.ejs
@@ -12,14 +12,14 @@
             <p class="text-[#b9bbbe] text-sm mb-6">ID: <%= botId %></p>
             
             <h2 class="text-xl font-semibold text-white mb-4 border-b border-[#40444b] pb-2">
-                Servidores donde eres administrador
+                <%= t('userPanel.servers_admin') %>
             </h2>
             
             <!-- Lista de servidores -->
             <div class="grid gap-3 mb-6">
                 <% if (servers.length === 0) { %>
                     <div class="p-4 bg-[#40444b] rounded-md text-center">
-                        <p class="text-[#b9bbbe]">No eres administrador en ningún servidor donde esté el bot.</p>
+                        <p class="text-[#b9bbbe]"><%= t('userPanel.no_servers') %></p>
                     </div>
                 <% } else { %>
                     <% servers.forEach(server => { %>

--- a/userPanel/views/layouts/main.ejs
+++ b/userPanel/views/layouts/main.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="<%= lang %>">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -120,6 +120,11 @@
                             </a>
                         </div>
                     <% } %>
+                    <select id="lang-select" class="bg-discord-dark-300 text-white text-sm rounded px-2 py-1">
+                        <% for(const l of languages) { %>
+                            <option value="<%= l %>" <% if (l === lang) { %>selected<% } %>><%= l.toUpperCase() %></option>
+                        <% } %>
+                    </select>
                 </div>
             </div>
         </div>
@@ -152,7 +157,7 @@
             
             <!-- Header del bottomsheet (solo visible en móvil) -->
             <div class="flex items-center justify-between p-3 border-b border-discord-dark-300 md:hidden">
-                <span class="text-discord-white font-medium">Modulos</span>
+                <span class="text-discord-white font-medium"><%= t('userPanel.modules') %></span>
                 <button id="closeServerBar" class="text-discord-white/60 hover:text-discord-white">
                     <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -175,7 +180,7 @@
                                 </svg>
                             <% } %>
                         </div>
-                        <span class="text-xs text-discord-white/80 truncate text-center"><%= item.label.length > 13 ? item.label.slice(0, 13) + '...' : item.label %></span>
+                        <span class="text-xs text-discord-white/80 truncate text-center"><%= t(item.label).length > 13 ? t(item.label).slice(0, 13) + '...' : t(item.label) %></span>
                     </a>
                 <% } %>
             </div>
@@ -231,7 +236,7 @@
                                 <% for (const item of section.items) { %>
                                     <a href="<%= item.url %>" class="flex items-center px-2 py-1.5 rounded text-discord-white/60 hover:text-discord-white hover:bg-discord-dark-200 transition-colors<% if (reqPath === item.url) { %> bg-discord-dark-200 text-white<% } %>">
                                         <span class="mr-1.5">#</span>
-                                        <span class="truncate"><%= item.label %></span>
+                                        <span class="truncate"><%= t(item.label) %></span>
                                         <% if (item.badge) { %>
                                             <span class="ml-auto bg-discord-primary text-xs px-1.5 py-0.5 rounded-full font-medium"><%= item.badge %></span>
                                         <% } %>
@@ -241,7 +246,7 @@
                         </div>
                     <% } %>
                 <% } else { %>
-                    <div class="mt-6 text-discord-white/40 text-xs px-2">Ninguna sección disponible</div>
+                    <div class="mt-6 text-discord-white/40 text-xs px-2"><%= t('userPanel.noSection') %></div>
                 <% } %>
 
             </div>
@@ -273,6 +278,13 @@
             const closeSidebarButton = document.getElementById('closeSidebar');
             const channelList = document.getElementById('channelList');
             const serverBar = document.getElementById('serverBar');
+            const langSelect = document.getElementById('lang-select');
+            if (langSelect) {
+                langSelect.addEventListener('change', function() {
+                    document.cookie = 'panel_lang=' + this.value + ';path=/;max-age=' + (30*24*60*60);
+                    location.reload();
+                });
+            }
             
             // Función para cerrar todos los menús móviles
             function closeAllMenus() {

--- a/userPanel/views/layouts/main.ejs
+++ b/userPanel/views/layouts/main.ejs
@@ -120,7 +120,7 @@
                             </a>
                         </div>
                     <% } %>
-                    <select id="lang-select" class="bg-discord-dark-300 text-white text-sm rounded px-2 py-1">
+                    <select id="lang-select" class="bg-discord-dark-300 text-white text-sm rounded px-2 py-1 h-[45px]">
                         <% for(const l of languages) { %>
                             <option value="<%= l %>" <% if (l === lang) { %>selected<% } %>><%= l.toUpperCase() %></option>
                         <% } %>
@@ -214,7 +214,7 @@
         <aside id="channelList" class="w-60 bg-discord-dark-300 h-screen fixed left-0 md:left-[72px] pt-3 overflow-y-auto pb-20 transform -translate-x-full md:translate-x-0 transition-transform duration-300 z-40">
             <div class="px-3">
                 <div class="flex items-center justify-between p-2 bg-discord-dark-400 rounded-lg hover:bg-discord-dark-200 cursor-pointer transition-colors">
-                    <span class="font-medium text-discord-white truncate"><%= selectedNavItem?.label || 'Panel de Control' %></span>
+                    <span class="font-medium text-discord-white truncate"><%= t(selectedNavItem?.label || 'Panel de Control')  %></span>
                     <svg class="w-4 h-4 flex-shrink-0 text-discord-white/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                     </svg>


### PR DESCRIPTION
## Summary
- load translations for the user panel
- detect browser language and store choice in a cookie
- allow changing language from a dropdown
- translate some navigation labels and dashboard messages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882157949c0832f9eb47879ba34e28e